### PR TITLE
Remove unused GITHUB_ISSUE_FIELD_ID env var check

### DIFF
--- a/.github/workflows/scripts/close-clickup-task.js
+++ b/.github/workflows/scripts/close-clickup-task.js
@@ -126,9 +126,8 @@ async function main() {
     const issueId = process.env.GITHUB_ISSUE_NUMBER;
     const clickupToken = process.env.CLICKUP_API_TOKEN;
     const workspaceId = process.env.CLICKUP_WORKSPACE_ID;
-    const issueFieldId = process.env.GITHUB_ISSUE_FIELD_ID;
 
-    if (!clickupToken || !workspaceId || !issueFieldId) {
+    if (!clickupToken || !workspaceId) {
       console.error('Required environment variables are missing');
       process.exit(1);
     }


### PR DESCRIPTION
The script no longer requires the GITHUB_ISSUE_FIELD_ID environment variable. This commit removes its usage from the required variables check.

# Pull Request Template

## 📋 Description

Please provide a short summary explaining your changes and the motivation behind them.

- [ ] Bug fix
- [ ] New documentation
- [ ] Update to existing docs
- [ ] Other (please describe):

## 🧪 Related Issues

Link any related GitHub issues or discussions here (e.g. `Closes #123`).

## 📝 Checklist

- [ ] I’ve tested my changes locally (if applicable).
- [ ] I’ve added sufficient documentation.
- [ ] I’ve reviewed existing open PRs for potential conflicts.
- [ ] I’ve followed the repository's contribution guidelines.

## 💬 Additional Comments

Add any additional context or screenshots here.
