### PR TITLE
fix: Update ClickUp task closing workflow with dependency installatio…

### DIFF
--- a/.github/workflows/close-clickup-task.yml
+++ b/.github/workflows/close-clickup-task.yml
@@ -16,10 +16,13 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install dependencies
+        run: npm install
+
       - name: Close ClickUp Task
         run: node .github/workflows/scripts/close-clickup-task.js
         env:
           GITHUB_ISSUE_NUMBER: ${{ github.event.issue.number }}
           CLICKUP_API_TOKEN: ${{ secrets.CLICKUP_API_TOKEN }}
-          CLICKUP_WORKSPACE_ID: ${{ secrets.CLICKUP_WORKSPACE_ID }}
+          CLICKUP_SPACE_ID: ${{ secrets.CLICKUP_SPACE_ID }}
           GITHUB_ISSUE_FIELD_ID: ${{ secrets.GITHUB_ISSUE_FIELD_ID }} 


### PR DESCRIPTION
…n and correct space ID

- Added a step to install npm dependencies before closing the ClickUp task.
- Changed environment variable from CLICKUP_WORKSPACE_ID to CLICKUP_SPACE_ID for accurate API integration.

# Pull Request Template

## 📋 Description

Please provide a short summary explaining your changes and the motivation behind them.

- [ ] Bug fix
- [ ] New documentation
- [ ] Update to existing docs
- [ ] Other (please describe):

## 🧪 Related Issues

Link any related GitHub issues or discussions here (e.g. `Closes #123`).

## 📝 Checklist

- [ ] I’ve tested my changes locally (if applicable).
- [ ] I’ve added sufficient documentation.
- [ ] I’ve reviewed existing open PRs for potential conflicts.
- [ ] I’ve followed the repository's contribution guidelines.

## 💬 Additional Comments

Add any additional context or screenshots here.
