### PR TITLE
Update env variable names for ClickUp integration

### DIFF
--- a/.github/workflows/close-clickup-task.yml
+++ b/.github/workflows/close-clickup-task.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Close ClickUp Task
         run: node .github/workflows/scripts/close-clickup-task.js
         env:
-          GITHUB_ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
           CLICKUP_API_TOKEN: ${{ secrets.CLICKUP_API_TOKEN }}
           CLICKUP_SPACE_ID: ${{ secrets.CLICKUP_SPACE_ID }}
-          GITHUB_ISSUE_FIELD_ID: ${{ secrets.GITHUB_ISSUE_FIELD_ID }} 
+          CLICKUP_GITHUB_FIELD_ID: ${{ secrets.CLICKUP_GITHUB_FIELD_ID }} 

--- a/.github/workflows/scripts/close-clickup-task.js
+++ b/.github/workflows/scripts/close-clickup-task.js
@@ -74,13 +74,13 @@ async function closeTask(taskId, apiToken) {
 }
 
 async function main() {
-  console.log(`🚀 ClickUp Task Closer - Issue #${process.env.GITHUB_ISSUE_NUMBER}`);
+  console.log(`🚀 ClickUp Task Closer - Issue #${process.env.ISSUE_NUMBER}`);
   
   // Get environment variables
-  const issueId = process.env.GITHUB_ISSUE_NUMBER;
+  const issueId = process.env.ISSUE_NUMBER;
   const apiToken = process.env.CLICKUP_API_TOKEN;
   const listId = process.env.CLICKUP_SPACE_ID; // This is actually the list ID
-  const githubFieldId = process.env.GITHUB_ISSUE_FIELD_ID;
+  const githubFieldId = process.env.CLICKUP_GITHUB_FIELD_ID;
   
   // Validate required variables
   if (!issueId || !apiToken || !listId || !githubFieldId) {


### PR DESCRIPTION
Renamed environment variables in the workflow and script for consistency and clarity: GITHUB_ISSUE_NUMBER to ISSUE_NUMBER and GITHUB_ISSUE_FIELD_ID to CLICKUP_GITHUB_FIELD_ID. This ensures the workflow and script use the correct variable names and improves maintainability.

# Pull Request Template

## 📋 Description

Please provide a short summary explaining your changes and the motivation behind them.

- [ ] Bug fix
- [ ] New documentation
- [ ] Update to existing docs
- [ ] Other (please describe):

## 🧪 Related Issues

Link any related GitHub issues or discussions here (e.g. `Closes #123`).

## 📝 Checklist

- [ ] I’ve tested my changes locally (if applicable).
- [ ] I’ve added sufficient documentation.
- [ ] I’ve reviewed existing open PRs for potential conflicts.
- [ ] I’ve followed the repository's contribution guidelines.

## 💬 Additional Comments

Add any additional context or screenshots here.
