### PR TITLE
fix: Improve ClickUp task handling in closure script

### DIFF
--- a/.github/workflows/scripts/close-clickup-task.js
+++ b/.github/workflows/scripts/close-clickup-task.js
@@ -5,10 +5,12 @@ function makeRequest(options, data = null) {
     method: options.method,
     url: `https://${options.hostname}${options.path}`,
     headers: options.headers,
-    data: data,
     timeout: 10000
   };
   
+  if (data) {
+    config.data = data;
+  }
   return axios(config)
     .then(response => response.data)
     .catch(error => {
@@ -26,7 +28,7 @@ async function findTaskInList(listId, issueId, githubFieldId, apiToken) {
   while (page < maxPages) {
     const options = {
       hostname: 'api.clickup.com',
-      path: `/api/v2/list/${listId}/task?page=${page}&include_closed=true`,
+      path: `/api/v2/list/${listId}/task?page=${page}`,
       method: 'GET',
       headers: {
         'Authorization': apiToken,
@@ -43,7 +45,7 @@ async function findTaskInList(listId, issueId, githubFieldId, apiToken) {
     for (const task of tasks) {
       if (task.custom_fields) {
         const githubField = task.custom_fields.find(field => field.id === githubFieldId);
-        if (githubField && githubField.value == issueId) {
+        if (githubField && githubField.value?.trim() == issueId) {
           console.log(`✅ Found task: ${task.id} - "${task.name}"`);
           return task.id;
         }
@@ -64,7 +66,7 @@ async function closeTask(taskId, apiToken) {
     path: `/api/v2/task/${taskId}`,
     method: 'PUT',
     headers: {
-      'Authorization': apiToken,
+      'Authorization': apiToken.trim(),
       'Content-Type': 'application/json'
     }
   };


### PR DESCRIPTION
- Added conditional data assignment in the axios request configuration to ensure data is sent only when provided.
- Removed unnecessary `include_closed` parameter from the task list API call for cleaner requests.
- Trimmed the API token in the authorization header to prevent potential issues with whitespace.
- Enhanced the check for the GitHub issue ID by using optional chaining to avoid errors with undefined values.

# Pull Request Template

## 📋 Description

Please provide a short summary explaining your changes and the motivation behind them.

- [ ] Bug fix
- [ ] New documentation
- [ ] Update to existing docs
- [ ] Other (please describe):

## 🧪 Related Issues

Link any related GitHub issues or discussions here (e.g. `Closes #123`).

## 📝 Checklist

- [ ] I’ve tested my changes locally (if applicable).
- [ ] I’ve added sufficient documentation.
- [ ] I’ve reviewed existing open PRs for potential conflicts.
- [ ] I’ve followed the repository's contribution guidelines.

## 💬 Additional Comments

Add any additional context or screenshots here.
