### PR TITLE
fix: add noteId param definition

### DIFF
--- a/apps/calendars.json
+++ b/apps/calendars.json
@@ -1753,6 +1753,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "noteId",
+            "required": true,
+            "in": "path",
+            "description": "Note ID",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -1828,6 +1837,15 @@
             "required": true,
             "in": "path",
             "description": "Appointment ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "noteId",
+            "required": true,
+            "in": "path",
+            "description": "Note ID",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
## 📋 Description

A bug in the calendar API specification which causes issues when trying to generate code.

- [x] Bug fix
- [ ] New documentation
- [ ] Update to existing docs
- [ ] Other (please describe):

## 📝 Checklist

- [x] I’ve tested my changes locally (if applicable).
- [x] I’ve reviewed existing open PRs for potential conflicts.
- [x] I’ve followed the repository's contribution guidelines.

## 💬 Additional Comments

> Semantic error at paths./calendars/appointments/{appointmentId}/notes/{noteId}
> Declared path parameter "noteId" needs to be defined as a path parameter at either the path or operation level
