### PR TITLE
fix: `CreateLocation` success response code

### DIFF
--- a/apps/locations.json
+++ b/apps/locations.json
@@ -2733,7 +2733,7 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Successful update response",
             "content": {
               "application/json": {


### PR DESCRIPTION
# Pull Request Template

## 📋 Description

The API returns a `201 Created` but the spec says `200 OK`.
Generated clients use status codes to map to the correct object types.

Example Jane PHP generated this which failed:

```php

    /**
     * {@inheritdoc}
     *
     * @throws \GHL\Locations\Exception\CreateLocationBadRequestException
     * @throws \GHL\Locations\Exception\CreateLocationUnauthorizedException
     *
     * @return null|\GHL\Locations\Model\CreateLocationSuccessfulResponseDto
     */
    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
    {
        $status = $response->getStatusCode();
        $body = (string) $response->getBody();
        if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
            return $serializer->deserialize($body, 'GHL\Locations\Model\CreateLocationSuccessfulResponseDto', 'json');
        }
        if (is_null($contentType) === false && (400 === $status && mb_strpos($contentType, 'application/json') !== false)) {
            throw new \GHL\Locations\Exception\CreateLocationBadRequestException($serializer->deserialize($body, 'GHL\Locations\Model\LocationsSearchGetResponse400', 'json'), $response);
        }
        if (is_null($contentType) === false && (401 === $status && mb_strpos($contentType, 'application/json') !== false)) {
            throw new \GHL\Locations\Exception\CreateLocationUnauthorizedException($serializer->deserialize($body, 'GHL\Locations\Model\LocationsSearchGetResponse401', 'json'), $response);
        }
    }
```

- [x] Bug fix

## 📝 Checklist

- [x] I’ve tested my changes locally (if applicable).
- [x] I’ve added sufficient documentation.
- [x] I’ve reviewed existing open PRs for potential conflicts.
- [x] I’ve followed the repository's contribution guidelines.
